### PR TITLE
Settings: Introduce new refresh rate selector page

### DIFF
--- a/AndroidManifest.xml
+++ b/AndroidManifest.xml
@@ -1415,6 +1415,26 @@
                        android:value="@string/menu_key_display"/>
         </activity>
 
+         <activity
+            android:name="Settings$RefreshRateSettingsActivity"
+            android:label="@string/refresh_rate_title"
+            android:exported="true">
+            <intent-filter android:priority="32">
+                <action android:name="android.intent.action.MAIN" />
+                <category android:name="com.android.settings.SHORTCUT" />
+            </intent-filter>
+            <intent-filter android:priority="1">
+                <action android:name="android.settings.REFRESH_RATE_SETTINGS" />
+                <category android:name="android.intent.category.DEFAULT" />
+            </intent-filter>
+            <meta-data android:name="com.android.settings.FRAGMENT_CLASS"
+                android:value="com.android.settings.display.RefreshRateSettings" />
+            <meta-data android:name="com.android.settings.HIGHLIGHT_MENU_KEY"
+                       android:value="@string/menu_key_display"/>
+            <meta-data android:name="com.android.settings.PRIMARY_PROFILE_CONTROLLED"
+                android:value="true" />
+        </activity>
+        
         <activity
             android:name="Settings$NightDisplaySettingsActivity"
             android:label="@string/night_display_title"

--- a/res/layout/private_dns_mode_dialog.xml
+++ b/res/layout/private_dns_mode_dialog.xml
@@ -43,6 +43,58 @@
                 android:id="@+id/private_dns_mode_provider"
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 
+            <include
+                android:id="@+id/private_dns_mode_adguard"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_appliedprivacy"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_cira"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_cleanbrowsing"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_cloudflare"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_cznic"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_google"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_mullvad"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_quadnine"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_restena"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_switch"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_twnic"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
+            <include
+                android:id="@+id/private_dns_mode_uncensoreddns"
+                layout="@layout/preference_widget_dialog_radiobutton"/>
+
             <EditText
                 android:id="@+id/private_dns_mode_provider_hostname"
                 android:hint="@string/private_dns_mode_provider_hostname_hint"

--- a/res/layout/private_dns_mode_dialog.xml
+++ b/res/layout/private_dns_mode_dialog.xml
@@ -36,10 +36,6 @@
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 
             <include
-                android:id="@+id/private_dns_mode_cloudflare"
-                layout="@layout/preference_widget_dialog_radiobutton"/>
-
-            <include
                 android:id="@+id/private_dns_mode_opportunistic"
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 

--- a/res/layout/private_dns_mode_dialog.xml
+++ b/res/layout/private_dns_mode_dialog.xml
@@ -40,10 +40,6 @@
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 
             <include
-                android:id="@+id/private_dns_mode_adguard"
-                layout="@layout/preference_widget_dialog_radiobutton"/>
-
-            <include
                 android:id="@+id/private_dns_mode_opportunistic"
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 

--- a/res/layout/private_dns_mode_dialog.xml
+++ b/res/layout/private_dns_mode_dialog.xml
@@ -44,18 +44,6 @@
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 
             <include
-                android:id="@+id/private_dns_mode_open_dns"
-                layout="@layout/preference_widget_dialog_radiobutton"/>
-
-            <include
-                android:id="@+id/private_dns_mode_cleanbrowsing"
-                layout="@layout/preference_widget_dialog_radiobutton"/>
-
-            <include
-                android:id="@+id/private_dns_mode_quad9"
-                layout="@layout/preference_widget_dialog_radiobutton"/>
-
-            <include
                 android:id="@+id/private_dns_mode_opportunistic"
                 layout="@layout/preference_widget_dialog_radiobutton"/>
 

--- a/res/values/alpha_strings.xml
+++ b/res/values/alpha_strings.xml
@@ -19,5 +19,14 @@
     <string name="private_dns_mode_switch" translatable="false">SWITCH (CH)</string>
     <string name="private_dns_mode_twnic" translatable="false">TW.NIC (TW)</string>
     <string name="private_dns_mode_uncensoreddns" translatable="false">UncensoredDNS (DK)</string>
+    
+    <!-- Refresh rate -->
+    <string name="refresh_rate_title">Refresh rate</string>
+    <string name="refresh_rate_summary_vrr_off">%d Hz</string>
+    <string name="refresh_rate_summary_vrr_on">%d Hz (Adaptive)</string>
+    <string name="refresh_rate_vrr_title">Adaptive refresh rate</string>
+    <string name="refresh_rate_vrr_summary">Automatically lower the refresh rate when the display is idle, to save power. May cause flickering or color shift on certain displays</string>
+    <string name="refresh_rate_footer">A higher refresh rate makes the display smoother, but increases power consumption</string>
+    <string name="keywords_refresh_rate">refresh, rate, smooth, peak, 60hz, 90hz, 120hz, 144hz, 165hz</string>
 
 </resources>

--- a/res/values/alpha_strings.xml
+++ b/res/values/alpha_strings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+     Copyright (C) 2023 VoltageOS
+     SPDX-License-Identifier: Apache-2.0
+-->
+<resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
+
+    <!-- Private DNS -->
+    <string name="private_dns_mode_adguard" translatable="false">AdGuard (CY)</string>
+    <string name="private_dns_mode_appliedprivacy" translatable="false">AppliedPrivacy (AT)</string>
+    <string name="private_dns_mode_cira" translatable="false">CIRA (CA)</string>
+    <string name="private_dns_mode_cleanbrowsing" translatable="false">CleanBrowsing (US)</string>
+    <string name="private_dns_mode_cloudflare" translatable="false">Cloudflare (US)</string>
+    <string name="private_dns_mode_cznic" translatable="false">CZ.NIC (CZ)</string>
+    <string name="private_dns_mode_google" translatable="false">Google (US)</string>
+    <string name="private_dns_mode_mullvad" translatable="false">Mullvad (SE)</string>
+    <string name="private_dns_mode_quadnine" translatable="false">Quad9 (CH)</string>
+    <string name="private_dns_mode_restena" translatable="false">Restena (LU)</string>
+    <string name="private_dns_mode_switch" translatable="false">SWITCH (CH)</string>
+    <string name="private_dns_mode_twnic" translatable="false">TW.NIC (TW)</string>
+    <string name="private_dns_mode_uncensoreddns" translatable="false">UncensoredDNS (DK)</string>
+
+</resources>

--- a/res/values/cm_strings.xml
+++ b/res/values/cm_strings.xml
@@ -15,11 +15,6 @@
      limitations under the License.
 -->
 <resources xmlns:xliff="urn:oasis:names:tc:xliff:document:1.2">
-    <!-- Private DNS -->
-    <string name="private_dns_mode_cloudflare" translatable="false">Cloudflare DNS</string>
-    <!-- Alternative: 1dot1dot1dot1.cloudflare-dns.com -->
-    <string name="private_dns_hostname_cloudflare" translatable="false">one.one.one.one</string>
-
     <!-- Advanced keyboard settings -->
     <string name="keyboard_extras_title">Extras</string>
     <string name="advanced_keyboard_settings_title">Advanced settings</string>

--- a/res/xml/display_settings.xml
+++ b/res/xml/display_settings.xml
@@ -162,6 +162,7 @@
             android:summary="@string/display_white_balance_summary"
             settings:controller="com.android.settings.display.DisplayWhiteBalancePreferenceController"/>
 
+        <!--
         <ListPreference
             android:key="max_refresh_rate"
             android:title="@string/max_refresh_rate_title"
@@ -179,7 +180,16 @@
             android:title="@string/peak_refresh_rate_title"
             android:summary="@string/peak_refresh_rate_summary"
             settings:controller="com.android.settings.display.PeakRefreshRatePreferenceController"/>
+        -->    
 
+        <Preference
+            android:key="refresh_rate"
+            android:title="@string/refresh_rate_title"
+            android:summary="@string/summary_placeholder"
+            android:fragment="com.android.settings.display.RefreshRateSettings"
+            settings:keywords="@string/keywords_refresh_rate"
+            settings:controller="com.android.settings.display.RefreshRatePreferenceController"/>
+        
         <SwitchPreference
             android:key="show_operator_name"
             android:title="@string/show_operator_name_title"

--- a/res/xml/refresh_rate_settings.xml
+++ b/res/xml/refresh_rate_settings.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="utf-8"?>
+<!--
+  Copyright (C) 2022 The Android Open Source Project
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+  -->
+
+<PreferenceScreen
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:settings="http://schemas.android.com/apk/res-auto"
+    android:title="@string/refresh_rate_title"
+    android:key="refresh_rate"
+    settings:staticPreferenceLocation="append" />

--- a/src/com/android/settings/Settings.java
+++ b/src/com/android/settings/Settings.java
@@ -123,6 +123,7 @@ public class Settings extends SettingsActivity {
     public static class NavigationModeSettingsActivity extends SettingsActivity { /* empty */ }
     public static class UserDictionarySettingsActivity extends SettingsActivity { /* empty */ }
     public static class DarkThemeSettingsActivity extends SettingsActivity { /* empty */ }
+    public static class RefreshRateSettingsActivity extends SettingsActivity { /* empty */ }
     public static class DisplaySettingsActivity extends SettingsActivity { /* empty */ }
     public static class NightDisplaySettingsActivity extends SettingsActivity { /* empty */ }
     public static class NightDisplaySuggestionActivity extends NightDisplaySettingsActivity { /* empty */ }

--- a/src/com/android/settings/core/gateway/SettingsGateway.java
+++ b/src/com/android/settings/core/gateway/SettingsGateway.java
@@ -105,6 +105,7 @@ import com.android.settings.display.NightDisplaySettings;
 import com.android.settings.display.SmartAutoRotatePreferenceFragment;
 import com.android.settings.display.darkmode.DarkModeSettingsFragment;
 import com.android.settings.dream.DreamSettings;
+import com.android.settings.display.RefreshRateSettings;
 import com.android.settings.enterprise.EnterprisePrivacySettings;
 import com.android.settings.fuelgauge.AdvancedPowerUsageDetail;
 import com.android.settings.fuelgauge.batterysaver.BatterySaverScheduleSettings;
@@ -241,6 +242,7 @@ public class SettingsGateway {
             FirmwareVersionSettings.class.getName(),
             ManageAssist.class.getName(),
             ProcessStatsUi.class.getName(),
+            RefreshRateSettings.class.getName(),
             NotificationStation.class.getName(),
             LocationSettings.class.getName(),
             WifiScanningFragment.class.getName(),

--- a/src/com/android/settings/development/DisableAutomaticUpdatesPreferenceController.java
+++ b/src/com/android/settings/development/DisableAutomaticUpdatesPreferenceController.java
@@ -73,4 +73,9 @@ public class DisableAutomaticUpdatesPreferenceController extends
                 Settings.Global.OTA_DISABLE_AUTOMATIC_UPDATE, DISABLE_UPDATES_SETTING);
         ((SwitchPreference) mPreference).setChecked(false);
     }
+
+    @Override
+    public boolean isAvailable() {
+        return false;
+    }
 }

--- a/src/com/android/settings/development/OverlayCategoryPreferenceController.java
+++ b/src/com/android/settings/development/OverlayCategoryPreferenceController.java
@@ -39,6 +39,7 @@ import com.android.settings.core.PreferenceControllerMixin;
 import com.android.settingslib.development.DeveloperOptionsPreferenceController;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
@@ -52,13 +53,13 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
     private static final String TAG = "OverlayCategoryPC";
     @VisibleForTesting
     static final String PACKAGE_DEVICE_DEFAULT = "package_device_default";
-    private static final String OVERLAY_TARGET_PACKAGE = "android";
     private static final Comparator<OverlayInfo> OVERLAY_INFO_COMPARATOR =
             Comparator.comparing(OverlayInfo::getPackageName);
     private final IOverlayManager mOverlayManager;
     private final boolean mAvailable;
     private final String mCategory;
     private final PackageManager mPackageManager;
+    private final String mDeviceDefaultLabel;
 
     private ListPreference mPreference;
 
@@ -70,6 +71,7 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
         mPackageManager = packageManager;
         mCategory = category;
         mAvailable = overlayManager != null && !getOverlayInfos().isEmpty();
+        mDeviceDefaultLabel = mContext.getString(R.string.overlay_option_device_default);
     }
 
     public OverlayCategoryPreferenceController(Context context, String category) {
@@ -103,30 +105,38 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
         return setOverlay((String) newValue);
     }
 
-    private boolean setOverlay(String packageName) {
-        final String currentPackageName = getOverlayInfos().stream()
+    private boolean setOverlay(String label) {
+        final String[] currentPackageNames = getOverlayInfos().stream()
                 .filter(info -> info.isEnabled())
                 .map(info -> info.packageName)
-                .findFirst()
-                .orElse(null);
+                .toArray(String[]::new);
 
-        if (PACKAGE_DEVICE_DEFAULT.equals(packageName) && TextUtils.isEmpty(currentPackageName)
-                || TextUtils.equals(packageName, currentPackageName)) {
-            // Already set.
-            return true;
-        }
+        final String[] packageNames = getOverlayInfos().stream()
+                .filter(info -> label.equals(getPackageLabel(info.packageName)))
+                .map(info -> info.packageName)
+                .toArray(String[]::new);
+
+        Log.w(TAG, "setOverlay currentPackageNames=" + currentPackageNames.toString());
+        Log.w(TAG, "setOverlay packageNames=" + packageNames.toString());
+        Log.w(TAG, "setOverlay label=" + label);
 
         new AsyncTask<Void, Void, Boolean>() {
             @Override
             protected Boolean doInBackground(Void... params) {
                 try {
-                    if (PACKAGE_DEVICE_DEFAULT.equals(packageName)) {
-                        return mOverlayManager.setEnabled(currentPackageName, false, USER_SYSTEM);
+                    if (label.equals(mDeviceDefaultLabel)) {
+                        for (String packageName : currentPackageNames) {
+                            Log.w(TAG, "setOverlay Disabing overlay" + packageName);
+                            mOverlayManager.setEnabled(packageName, false, USER_SYSTEM);
+                        }
                     } else {
-                        return mOverlayManager.setEnabledExclusiveInCategory(packageName,
-                                USER_SYSTEM);
+                        for (String packageName : packageNames) {
+                            Log.w(TAG, "setOverlay Enabling overlay" + packageName);
+                            mOverlayManager.setEnabledExclusiveInCategory(packageName, USER_SYSTEM);
+                        }
                     }
-                } catch (SecurityException | IllegalStateException | RemoteException e) {
+                    return true;
+                } catch (Exception e) {
                     Log.w(TAG, "Error enabling overlay.", e);
                     return false;
                 }
@@ -148,60 +158,58 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
 
     @Override
     public void updateState(Preference preference) {
-        final List<String> pkgs = new ArrayList<>();
         final List<String> labels = new ArrayList<>();
 
-        String selectedPkg = PACKAGE_DEVICE_DEFAULT;
-        String selectedLabel = mContext.getString(R.string.overlay_option_device_default);
+        String selectedLabel = mDeviceDefaultLabel;
 
-        // Add the default package / label before all of the overlays
-        pkgs.add(selectedPkg);
+        // Add the default label before all of the overlays
         labels.add(selectedLabel);
 
         for (OverlayInfo overlayInfo : getOverlayInfos()) {
-            pkgs.add(overlayInfo.packageName);
-            try {
-                labels.add(mPackageManager.getApplicationInfo(overlayInfo.packageName, 0)
-                        .loadLabel(mPackageManager).toString());
-            } catch (PackageManager.NameNotFoundException e) {
-                labels.add(overlayInfo.packageName);
+            String label = getPackageLabel(overlayInfo.packageName);
+            if (!labels.contains(label)) {
+                labels.add(label);
             }
             if (overlayInfo.isEnabled()) {
-                selectedPkg = pkgs.get(pkgs.size() - 1);
-                selectedLabel = labels.get(labels.size() - 1);
+                Log.w(TAG, "updateState Selecting label"+label);
+                selectedLabel = label;
             }
         }
 
         mPreference.setEntries(labels.toArray(new String[labels.size()]));
-        mPreference.setEntryValues(pkgs.toArray(new String[pkgs.size()]));
-        mPreference.setValue(selectedPkg);
+        mPreference.setEntryValues(labels.toArray(new String[labels.size()]));
+        mPreference.setValue(selectedLabel);
         mPreference.setSummary(selectedLabel);
     }
 
     private List<OverlayInfo> getOverlayInfos() {
         final List<OverlayInfo> filteredInfos = new ArrayList<>();
         try {
-            List<OverlayInfo> overlayInfos = mOverlayManager
-                    .getOverlayInfosForTarget(OVERLAY_TARGET_PACKAGE, USER_SYSTEM);
-            for (OverlayInfo overlayInfo : overlayInfos) {
-                if (mCategory.equals(overlayInfo.category)) {
-                    filteredInfos.add(overlayInfo);
+            Collection<List<OverlayInfo>> allOverlays = mOverlayManager
+                                              .getAllOverlays(USER_SYSTEM).values();
+            for (List<OverlayInfo> overlayInfos : allOverlays) {
+                for (OverlayInfo overlayInfo : overlayInfos) {
+                    if (overlayInfo.category != null) {
+                        if (overlayInfo.category.contains(mCategory)) {
+                            filteredInfos.add(overlayInfo);
+                        }
+                    }
                 }
             }
         } catch (RemoteException re) {
             throw re.rethrowFromSystemServer();
         }
         filteredInfos.sort(OVERLAY_INFO_COMPARATOR);
+        Log.w(TAG, "getOverlays list=" + filteredInfos.toString());
         return filteredInfos;
     }
 
-    @Override
-    protected void onDeveloperOptionsSwitchDisabled() {
-        super.onDeveloperOptionsSwitchDisabled();
-        // TODO b/133222035: remove these developer settings when the
-        // Settings.Secure.THEME_CUSTOMIZATION_OVERLAY_PACKAGES setting is used
-        setOverlay(PACKAGE_DEVICE_DEFAULT);
-        updateState(mPreference);
+    private String getPackageLabel(String packageName) {
+        try {
+            return mPackageManager.getApplicationInfo(packageName, 0)
+                                  .loadLabel(mPackageManager).toString();
+        } catch (PackageManager.NameNotFoundException e) {
+            return mDeviceDefaultLabel;
+        }
     }
-
 }

--- a/src/com/android/settings/development/OverlayCategoryPreferenceController.java
+++ b/src/com/android/settings/development/OverlayCategoryPreferenceController.java
@@ -25,6 +25,8 @@ import android.content.pm.PackageManager;
 import android.os.AsyncTask;
 import android.os.RemoteException;
 import android.os.ServiceManager;
+import android.os.UserHandle;
+import android.provider.Settings;
 import android.text.TextUtils;
 import android.util.Log;
 import android.widget.Toast;
@@ -43,6 +45,9 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 
+import org.json.JSONException;
+import org.json.JSONObject;
+
 /**
  * Preference controller to allow users to choose an overlay from a list for a given category.
  * The chosen overlay is enabled exclusively within its category. A default option is also
@@ -51,12 +56,23 @@ import java.util.List;
 public class OverlayCategoryPreferenceController extends DeveloperOptionsPreferenceController
         implements Preference.OnPreferenceChangeListener, PreferenceControllerMixin {
     private static final String TAG = "OverlayCategoryPC";
+    private static final String FONT_KEY = "android.theme.customization.font";
+    private static final String ADAPTIVE_ICON_SHAPE_KEY = "android.theme.customization.adaptive_icon_shape";
+    private static final String ICON_PACK_KEY = "android.theme.customization.icon_pack";
+    private static final String SIGNAL_ICON_KEY = "android.theme.customization.signal_icon";
+    private static final String WIFI_ICON_KEY = "android.theme.customization.wifi_icon";
+
     @VisibleForTesting
     static final String PACKAGE_DEVICE_DEFAULT = "package_device_default";
     private static final Comparator<OverlayInfo> OVERLAY_INFO_COMPARATOR =
             Comparator.comparing(OverlayInfo::getPackageName);
     private final IOverlayManager mOverlayManager;
     private final boolean mAvailable;
+    private final boolean mIsFonts;
+    private final boolean mIsAdaptiveIconShape;
+    private final boolean mIsIconPack;
+    private final boolean mIsSignalIcon;
+    private final boolean mIsWiFiIcon;
     private final String mCategory;
     private final PackageManager mPackageManager;
     private final String mDeviceDefaultLabel;
@@ -72,6 +88,11 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
         mCategory = category;
         mAvailable = overlayManager != null && !getOverlayInfos().isEmpty();
         mDeviceDefaultLabel = mContext.getString(R.string.overlay_option_device_default);
+        mIsFonts = FONT_KEY.equals(category);
+        mIsAdaptiveIconShape = ADAPTIVE_ICON_SHAPE_KEY.equals(category);
+        mIsIconPack = ICON_PACK_KEY.equals(category);
+        mIsSignalIcon = SIGNAL_ICON_KEY.equals(category);
+        mIsWiFiIcon = WIFI_ICON_KEY.equals(category);
     }
 
     public OverlayCategoryPreferenceController(Context context, String category) {
@@ -106,19 +127,61 @@ public class OverlayCategoryPreferenceController extends DeveloperOptionsPrefere
     }
 
     private boolean setOverlay(String label) {
-        final String[] currentPackageNames = getOverlayInfos().stream()
-                .filter(info -> info.isEnabled())
-                .map(info -> info.packageName)
-                .toArray(String[]::new);
+        final List<OverlayInfo> infos = getOverlayInfos();
 
-        final String[] packageNames = getOverlayInfos().stream()
-                .filter(info -> label.equals(getPackageLabel(info.packageName)))
-                .map(info -> info.packageName)
-                .toArray(String[]::new);
+        ArrayList<String> currentPackageNames = new ArrayList<>();;
+        ArrayList<String> currentCategoryNames = new ArrayList<>();;
+        ArrayList<String> packageNames = new ArrayList<>();;
+        ArrayList<String> categoryNames = new ArrayList<>();;
+
+        for (OverlayInfo info : infos) {
+            if (info.isEnabled()) {
+                currentPackageNames.add(info.packageName);
+                currentCategoryNames.add(info.category);
+            }
+            if (label.equals(getPackageLabel(info.packageName))) {
+                packageNames.add(info.packageName);
+                categoryNames.add(info.category);
+            }
+        }
 
         Log.w(TAG, "setOverlay currentPackageNames=" + currentPackageNames.toString());
         Log.w(TAG, "setOverlay packageNames=" + packageNames.toString());
         Log.w(TAG, "setOverlay label=" + label);
+
+        if (mIsFonts || mIsAdaptiveIconShape || mIsIconPack || mIsSignalIcon || mIsWiFiIcon) {
+            // For overlays, we also need to set this setting
+            String value = Settings.Secure.getStringForUser(mContext.getContentResolver(),
+                    Settings.Secure.THEME_CUSTOMIZATION_OVERLAY_PACKAGES, UserHandle.USER_CURRENT);
+            JSONObject json;
+            if (value == null) {
+                json = new JSONObject();
+            } else {
+                try {
+                    json = new JSONObject(value);
+                } catch (JSONException e) {
+                    Log.e(TAG, "Error parsing current settings value:\n" + e.getMessage());
+                    return false;
+                }
+            }
+            // removing all currently enabled overlays from the json
+            for (String categoryName : currentCategoryNames) {
+                json.remove(categoryName);
+            }
+            // adding the new ones
+            for (int i = 0; i < categoryNames.size(); i++) {
+                try {
+                    json.put(categoryNames.get(i), packageNames.get(i));
+                } catch (JSONException e) {
+                    Log.e(TAG, "Error adding new settings value:\n" + e.getMessage());
+                    return false;
+                }
+            }
+            // updating the setting
+            Settings.Secure.putStringForUser(mContext.getContentResolver(),
+                    Settings.Secure.THEME_CUSTOMIZATION_OVERLAY_PACKAGES,
+                    json.toString(), UserHandle.USER_CURRENT);
+        }
 
         new AsyncTask<Void, Void, Boolean>() {
             @Override

--- a/src/com/android/settings/display/RefreshRatePreferenceController.java
+++ b/src/com/android/settings/display/RefreshRatePreferenceController.java
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.BroadcastReceiver;
+import android.content.Context;
+import android.content.Intent;
+import android.content.IntentFilter;
+import android.os.PowerManager;
+
+import androidx.preference.Preference;
+import androidx.preference.PreferenceScreen;
+
+import com.android.settings.R;
+import com.android.settings.core.BasePreferenceController;
+import com.android.settingslib.core.lifecycle.LifecycleObserver;
+import com.android.settingslib.core.lifecycle.events.OnStart;
+import com.android.settingslib.core.lifecycle.events.OnStop;
+
+public class RefreshRatePreferenceController extends BasePreferenceController
+        implements LifecycleObserver, OnStart, OnStop {
+
+    private static final String TAG = "RefreshRatePreferenceController";
+
+    private RefreshRateUtils mUtils;
+    private Preference mPreference;
+    private final PowerManager mPowerManager;
+
+    private final BroadcastReceiver mReceiver = new BroadcastReceiver() {
+        @Override
+        public void onReceive(Context context, Intent intent) {
+            if (mPreference != null)
+                updateState(mPreference);
+        }
+    };
+
+    public RefreshRatePreferenceController(Context context, String preferenceKey) {
+        super(context, preferenceKey);
+        mUtils = new RefreshRateUtils(context);
+        mPowerManager = context.getSystemService(PowerManager.class);
+    }
+
+    @Override
+    public void onStart() {
+        mContext.registerReceiver(mReceiver,
+                new IntentFilter(PowerManager.ACTION_POWER_SAVE_MODE_CHANGED));
+    }
+
+    @Override
+    public void onStop() {
+        mContext.unregisterReceiver(mReceiver);
+    }
+
+    @Override
+    public void displayPreference(PreferenceScreen screen) {
+        super.displayPreference(screen);
+        mPreference = screen.findPreference(getPreferenceKey());
+    }
+
+    @Override
+    public CharSequence getSummary() {
+        if (mPowerManager.isPowerSaveMode()) {
+            return mContext.getString(R.string.dark_ui_mode_disabled_summary_dark_theme_on);
+        }
+        return mContext.getString(mUtils.isVrrEnabled() ? R.string.refresh_rate_summary_vrr_on
+                : R.string.refresh_rate_summary_vrr_off, mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    public int getAvailabilityStatus() {
+        return mUtils.isHighRefreshRateAvailable() ? AVAILABLE : UNSUPPORTED_ON_DEVICE;
+    }
+
+    @Override
+    public void updateState(Preference preference) {
+        super.updateState(preference);
+        preference.setEnabled(!mPowerManager.isPowerSaveMode());
+    }
+}

--- a/src/com/android/settings/display/RefreshRateSettings.java
+++ b/src/com/android/settings/display/RefreshRateSettings.java
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2023 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.graphics.drawable.Drawable;
+import android.util.Log;
+
+import androidx.preference.PreferenceScreen;
+import androidx.preference.SwitchPreference;
+
+import com.android.settings.R;
+import com.android.settings.search.BaseSearchIndexProvider;
+import com.android.settings.widget.RadioButtonPickerFragment;
+import com.android.settingslib.search.SearchIndexable;
+import com.android.settingslib.widget.CandidateInfo;
+import com.android.settingslib.widget.FooterPreference;
+import com.android.settingslib.widget.MainSwitchPreference;
+import com.android.settingslib.widget.SelectorWithWidgetPreference;
+import com.android.settingslib.widget.TopIntroPreference;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+/** Preference fragment used for switching refresh rate */
+@SearchIndexable
+public class RefreshRateSettings extends RadioButtonPickerFragment {
+
+    private static final String TAG = "RefreshRateSettings";
+    private static final String KEY_VRR_PREF = "refresh_rate_vrr";
+
+    private Context mContext;
+    private RefreshRateUtils mUtils;
+    private SwitchPreference mVrrSwitchPref;
+
+    @Override
+    public void onAttach(Context context) {
+        super.onAttach(context);
+        mContext = context;
+        mUtils = new RefreshRateUtils(context);
+    }
+
+    @Override
+    protected int getPreferenceScreenResId() {
+        return R.xml.refresh_rate_settings;
+    }
+
+    @Override
+    protected void addStaticPreferences(PreferenceScreen screen) {
+        mVrrSwitchPref = new SwitchPreference(screen.getContext());
+        mVrrSwitchPref.setKey(KEY_VRR_PREF);
+        mVrrSwitchPref.setTitle(R.string.refresh_rate_vrr_title);
+        mVrrSwitchPref.setSummary(R.string.refresh_rate_vrr_summary);
+        mVrrSwitchPref.setOnPreferenceChangeListener((pref, newValue) -> {
+            mUtils.setVrrEnabled((Boolean) newValue);
+            return true;
+        });
+        screen.addPreference(mVrrSwitchPref);
+        updateVrrPref();
+
+        final FooterPreference footerPreference = new FooterPreference(screen.getContext());
+        footerPreference.setTitle(R.string.refresh_rate_footer);
+        footerPreference.setSelectable(false);
+        footerPreference.setLayoutResource(R.layout.preference_footer);
+        screen.addPreference(footerPreference);
+    }
+
+    @Override
+    protected List<? extends CandidateInfo> getCandidates() {
+        return mUtils.getRefreshRates().stream()
+                .filter(r -> r >= RefreshRateUtils.DEFAULT_REFRESH_RATE)
+                .map(RefreshRateCandidateInfo::new)
+                .collect(Collectors.toList());
+    }
+
+    private void updateVrrPref() {
+        if (mVrrSwitchPref == null) return;
+        mVrrSwitchPref.setEnabled(mUtils.isVrrPossible());
+        mVrrSwitchPref.setChecked(mUtils.isVrrEnabled());
+    }
+
+    @Override
+    protected String getDefaultKey() {
+        return String.valueOf(mUtils.getCurrentRefreshRate());
+    }
+
+    @Override
+    protected boolean setDefaultKey(final String key) {
+        final int refreshRate = Integer.parseInt(key);
+        mUtils.setCurrentRefreshRate(refreshRate);
+        updateVrrPref();
+        return true;
+    }
+
+    @Override
+    public int getMetricsCategory() {
+        return -1;
+    }
+
+    private class RefreshRateCandidateInfo extends CandidateInfo {
+        private final CharSequence mLabel;
+        private final String mKey;
+
+        RefreshRateCandidateInfo(Integer refreshRate) {
+            super(true);
+            mLabel = String.format("%d Hz", refreshRate.intValue());
+            mKey = refreshRate.toString();
+        }
+
+        @Override
+        public CharSequence loadLabel() {
+            return mLabel;
+        }
+
+        @Override
+        public Drawable loadIcon() {
+            return null;
+        }
+
+        @Override
+        public String getKey() {
+            return mKey;
+        }
+    }
+
+    public static final BaseSearchIndexProvider SEARCH_INDEX_DATA_PROVIDER =
+            new BaseSearchIndexProvider(R.xml.refresh_rate_settings) {
+                @Override
+                protected boolean isPageSearchEnabled(Context context) {
+                    return new RefreshRateUtils(context).isHighRefreshRateAvailable();
+                }
+            };
+}

--- a/src/com/android/settings/display/RefreshRateUtils.java
+++ b/src/com/android/settings/display/RefreshRateUtils.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright (C) 2024 Paranoid Android
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.android.settings.display;
+
+import android.content.Context;
+import android.provider.Settings;
+import android.util.Log;
+
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class RefreshRateUtils {
+
+    private static final String TAG = "RefreshRateUtils";
+
+    static final int DEFAULT_REFRESH_RATE = 60;
+    static final int DEFAULT_MIN_REFRESH_RATE = 0; // matches fwb. should be 60 though?
+
+    private Context mContext;
+    private List<Integer> mRefreshRates;
+    private int mMinRefreshRate, mMaxRefreshRate;
+
+    RefreshRateUtils(Context context) {
+        mContext = context;
+        mRefreshRates = getRefreshRates();
+        mMinRefreshRate = Collections.min(mRefreshRates);
+        mMaxRefreshRate = Collections.max(mRefreshRates);
+    }
+
+    List<Integer> getRefreshRates() {
+        return Arrays.stream(mContext.getDisplay().getSupportedModes())
+                .map(m -> Math.round(m.getRefreshRate()))
+                .sorted().distinct().collect(Collectors.toList());
+    }
+
+    boolean isHighRefreshRateAvailable() {
+        return mRefreshRates.stream()
+                .filter(r -> r > DEFAULT_REFRESH_RATE)
+                .count() > 0;
+    }
+
+    private int roundToNearestRefreshRate(int refreshRate, boolean floor) {
+        if (mRefreshRates.contains(refreshRate)) return refreshRate;
+        int findRefreshRate = mMinRefreshRate;
+        for (Integer knownRefreshRate : mRefreshRates) {
+            if (!floor) findRefreshRate = knownRefreshRate;
+            if (knownRefreshRate > refreshRate) break;
+            if (floor) findRefreshRate = knownRefreshRate;
+        }
+        return findRefreshRate;
+    }
+
+    private float getDefaultPeakRefreshRate() {
+        return (float) mContext.getResources().getInteger(
+                com.android.internal.R.integer.config_defaultPeakRefreshRate);
+    }
+
+    private int getPeakRefreshRate() {
+        final int peakRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, getDefaultPeakRefreshRate()));
+        return peakRefreshRate < mMinRefreshRate ? mMaxRefreshRate
+                : roundToNearestRefreshRate(peakRefreshRate, true);
+    }
+
+    private void setPeakRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.PEAK_REFRESH_RATE, (float) refreshRate);
+    }
+
+    private int getMinRefreshRate() {
+        final int minRefreshRate = Math.round(Settings.System.getFloat(
+                mContext.getContentResolver(), Settings.System.MIN_REFRESH_RATE,
+                (float) DEFAULT_MIN_REFRESH_RATE));
+        return minRefreshRate == DEFAULT_MIN_REFRESH_RATE ? DEFAULT_MIN_REFRESH_RATE
+                : roundToNearestRefreshRate(minRefreshRate, false);
+    }
+
+    private void setMinRefreshRate(int refreshRate) {
+        Settings.System.putFloat(mContext.getContentResolver(),
+                Settings.System.MIN_REFRESH_RATE, (float) refreshRate);
+    }
+
+    int getCurrentRefreshRate() {
+        return Math.max(getMinRefreshRate(), getPeakRefreshRate());
+    }
+
+    void setCurrentRefreshRate(int refreshRate) {
+        setPeakRefreshRate(refreshRate);
+        setMinRefreshRate(isVrrEnabled() ? DEFAULT_MIN_REFRESH_RATE : refreshRate);
+    }
+
+    boolean isVrrPossible() {
+        return getCurrentRefreshRate() > DEFAULT_REFRESH_RATE;
+    }
+
+    boolean isVrrEnabled() {
+        return getMinRefreshRate() <= DEFAULT_MIN_REFRESH_RATE;
+    }
+
+    void setVrrEnabled(boolean enable) {
+        setMinRefreshRate(enable ? DEFAULT_MIN_REFRESH_RATE : getCurrentRefreshRate());
+    }
+}

--- a/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
+++ b/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
@@ -72,9 +72,37 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     // DNS_MODE -> RadioButton id
     private static final Map<Integer, Integer> PRIVATE_DNS_MAP;
 
+    // Must match ConnectivitySettingsUtils
+    private static final int PRIVATE_DNS_MODE_ADGUARD = 4;
+    private static final int PRIVATE_DNS_MODE_APPLIEDPRIVACY = 5;
+    private static final int PRIVATE_DNS_MODE_CLEANBROWSING = 6;
+    private static final int PRIVATE_DNS_MODE_CIRA = 7;
+    private static final int PRIVATE_DNS_MODE_CZNIC = 8;
+    private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 9;
+    private static final int PRIVATE_DNS_MODE_GOOGLE = 10;
+    private static final int PRIVATE_DNS_MODE_MULLVAD = 11;
+    private static final int PRIVATE_DNS_MODE_QUADNINE = 12;
+    private static final int PRIVATE_DNS_MODE_RESTENA = 13;
+    private static final int PRIVATE_DNS_MODE_SWITCH = 14;
+    private static final int PRIVATE_DNS_MODE_TWNIC = 15;
+    private static final int PRIVATE_DNS_MODE_UNCENSOREDDNS = 16;
+
     static {
         PRIVATE_DNS_MAP = new HashMap<>();
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OFF, R.id.private_dns_mode_off);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_ADGUARD, R.id.private_dns_mode_adguard);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_APPLIEDPRIVACY, R.id.private_dns_mode_appliedprivacy);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLEANBROWSING, R.id.private_dns_mode_cleanbrowsing);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CIRA, R.id.private_dns_mode_cira);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CZNIC, R.id.private_dns_mode_cznic);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLOUDFLARE, R.id.private_dns_mode_cloudflare);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_GOOGLE, R.id.private_dns_mode_google);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_MULLVAD, R.id.private_dns_mode_mullvad);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_QUADNINE, R.id.private_dns_mode_quadnine);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_RESTENA, R.id.private_dns_mode_restena);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_SWITCH, R.id.private_dns_mode_switch);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_TWNIC, R.id.private_dns_mode_twnic);
+        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_UNCENSOREDDNS, R.id.private_dns_mode_uncensoreddns);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OPPORTUNISTIC, R.id.private_dns_mode_opportunistic);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_PROVIDER_HOSTNAME, R.id.private_dns_mode_provider);
     }
@@ -156,6 +184,45 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
         // Initial radio button text
         final RadioButton offRadioButton = view.findViewById(R.id.private_dns_mode_off);
         offRadioButton.setText(R.string.private_dns_mode_off);
+        final RadioButton adguardRadioButton =
+                view.findViewById(R.id.private_dns_mode_adguard);
+        adguardRadioButton.setText(R.string.private_dns_mode_adguard);
+        final RadioButton appliedprivacyRadioButton =
+                view.findViewById(R.id.private_dns_mode_appliedprivacy);
+        appliedprivacyRadioButton.setText(R.string.private_dns_mode_appliedprivacy);
+        final RadioButton ciraRadioButton =
+                view.findViewById(R.id.private_dns_mode_cira);
+        ciraRadioButton.setText(R.string.private_dns_mode_cira);
+        final RadioButton cleanbrowsingRadioButton =
+                view.findViewById(R.id.private_dns_mode_cleanbrowsing);
+        cleanbrowsingRadioButton.setText(R.string.private_dns_mode_cleanbrowsing);
+        final RadioButton cloudflareRadioButton =
+                view.findViewById(R.id.private_dns_mode_cloudflare);
+        cloudflareRadioButton.setText(R.string.private_dns_mode_cloudflare);
+        final RadioButton cznicRadioButton =
+                view.findViewById(R.id.private_dns_mode_cznic);
+        cznicRadioButton.setText(R.string.private_dns_mode_cznic);
+        final RadioButton googleRadioButton =
+                view.findViewById(R.id.private_dns_mode_google);
+        googleRadioButton.setText(R.string.private_dns_mode_google);
+        final RadioButton mullvadRadioButton =
+                view.findViewById(R.id.private_dns_mode_mullvad);
+        mullvadRadioButton.setText(R.string.private_dns_mode_mullvad);
+        final RadioButton quadnineRadioButton =
+                view.findViewById(R.id.private_dns_mode_quadnine);
+        quadnineRadioButton.setText(R.string.private_dns_mode_quadnine);
+        final RadioButton restenaRadioButton =
+                view.findViewById(R.id.private_dns_mode_restena);
+        restenaRadioButton.setText(R.string.private_dns_mode_restena);
+        final RadioButton switchRadioButton =
+                view.findViewById(R.id.private_dns_mode_switch);
+        switchRadioButton.setText(R.string.private_dns_mode_switch);
+        final RadioButton twnicRadioButton =
+                view.findViewById(R.id.private_dns_mode_twnic);
+        twnicRadioButton.setText(R.string.private_dns_mode_twnic);
+        final RadioButton uncensoreddnsRadioButton =
+                view.findViewById(R.id.private_dns_mode_uncensoreddns);
+        uncensoreddnsRadioButton.setText(R.string.private_dns_mode_uncensoreddns);
         final RadioButton opportunisticRadioButton =
                 view.findViewById(R.id.private_dns_mode_opportunistic);
         opportunisticRadioButton.setText(R.string.private_dns_mode_opportunistic);
@@ -197,6 +264,32 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     public void onCheckedChanged(RadioGroup group, int checkedId) {
         if (checkedId == R.id.private_dns_mode_off) {
             mMode = PRIVATE_DNS_MODE_OFF;
+        } else if (checkedId == R.id.private_dns_mode_adguard) {
+            mMode = PRIVATE_DNS_MODE_ADGUARD;
+        } else if (checkedId == R.id.private_dns_mode_appliedprivacy) {
+            mMode = PRIVATE_DNS_MODE_APPLIEDPRIVACY;
+        } else if (checkedId == R.id.private_dns_mode_cira) {
+            mMode = PRIVATE_DNS_MODE_CIRA;
+        } else if (checkedId == R.id.private_dns_mode_cleanbrowsing) {
+            mMode = PRIVATE_DNS_MODE_CLEANBROWSING;
+        } else if (checkedId == R.id.private_dns_mode_cloudflare) {
+            mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
+        } else if (checkedId == R.id.private_dns_mode_cznic) {
+            mMode = PRIVATE_DNS_MODE_CZNIC;
+        } else if (checkedId == R.id.private_dns_mode_google) {
+            mMode = PRIVATE_DNS_MODE_GOOGLE;
+        } else if (checkedId == R.id.private_dns_mode_mullvad) {
+            mMode = PRIVATE_DNS_MODE_MULLVAD;
+        } else if (checkedId == R.id.private_dns_mode_quadnine) {
+            mMode = PRIVATE_DNS_MODE_QUADNINE;
+        } else if (checkedId == R.id.private_dns_mode_restena) {
+            mMode = PRIVATE_DNS_MODE_RESTENA;
+        } else if (checkedId == R.id.private_dns_mode_switch) {
+            mMode = PRIVATE_DNS_MODE_SWITCH;
+        } else if (checkedId == R.id.private_dns_mode_twnic) {
+            mMode = PRIVATE_DNS_MODE_TWNIC;
+        } else if (checkedId == R.id.private_dns_mode_uncensoreddns) {
+            mMode = PRIVATE_DNS_MODE_UNCENSOREDDNS;
         } else if (checkedId == R.id.private_dns_mode_opportunistic) {
             mMode = PRIVATE_DNS_MODE_OPPORTUNISTIC;
         } else if (checkedId == R.id.private_dns_mode_provider) {

--- a/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
+++ b/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
@@ -72,13 +72,9 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     // DNS_MODE -> RadioButton id
     private static final Map<Integer, Integer> PRIVATE_DNS_MAP;
 
-    // Only used in Settings, update on additions to ConnectivitySettingsUtils
-    private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
-
     static {
         PRIVATE_DNS_MAP = new HashMap<>();
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OFF, R.id.private_dns_mode_off);
-        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLOUDFLARE, R.id.private_dns_mode_cloudflare);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OPPORTUNISTIC, R.id.private_dns_mode_opportunistic);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_PROVIDER_HOSTNAME, R.id.private_dns_mode_provider);
     }
@@ -148,15 +144,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
         final ContentResolver contentResolver = context.getContentResolver();
 
         mMode = ConnectivitySettingsManager.getPrivateDnsMode(context);
-        if (mMode == PRIVATE_DNS_MODE_PROVIDER_HOSTNAME) {
-            final String privateDnsHostname =
-                    ConnectivitySettingsManager.getPrivateDnsHostname(context);
-            final String cloudflareHostname =
-                    context.getString(R.string.private_dns_hostname_cloudflare);
-            if (privateDnsHostname.equals(cloudflareHostname)) {
-                mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
-            }
-        }
 
         mEditText = view.findViewById(R.id.private_dns_mode_provider_hostname);
         mEditText.addTextChangedListener(this);
@@ -169,9 +156,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
         // Initial radio button text
         final RadioButton offRadioButton = view.findViewById(R.id.private_dns_mode_off);
         offRadioButton.setText(R.string.private_dns_mode_off);
-        final RadioButton cloudflareRadioButton =
-                view.findViewById(R.id.private_dns_mode_cloudflare);
-        cloudflareRadioButton.setText(R.string.private_dns_mode_cloudflare);
         final RadioButton opportunisticRadioButton =
                 view.findViewById(R.id.private_dns_mode_opportunistic);
         opportunisticRadioButton.setText(R.string.private_dns_mode_opportunistic);
@@ -197,21 +181,15 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     public void onClick(DialogInterface dialog, int which) {
         if (which == DialogInterface.BUTTON_POSITIVE) {
             final Context context = getContext();
-            int modeToSet = mMode;
             if (mMode == PRIVATE_DNS_MODE_PROVIDER_HOSTNAME) {
                 // Only clickable if hostname is valid, so we could save it safely
                 ConnectivitySettingsManager.setPrivateDnsHostname(context,
                         mEditText.getText().toString());
-            } else if (mMode == PRIVATE_DNS_MODE_CLOUDFLARE) {
-                final String cloudflareHostname =
-                        context.getString(R.string.private_dns_hostname_cloudflare);
-                ConnectivitySettingsManager.setPrivateDnsHostname(context, cloudflareHostname);
-                modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
             }
 
             FeatureFactory.getFactory(context).getMetricsFeatureProvider().action(context,
-                    SettingsEnums.ACTION_PRIVATE_DNS_MODE, modeToSet);
-            ConnectivitySettingsManager.setPrivateDnsMode(context, modeToSet);
+                    SettingsEnums.ACTION_PRIVATE_DNS_MODE, mMode);
+            ConnectivitySettingsManager.setPrivateDnsMode(context, mMode);
         }
     }
 
@@ -219,8 +197,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     public void onCheckedChanged(RadioGroup group, int checkedId) {
         if (checkedId == R.id.private_dns_mode_off) {
             mMode = PRIVATE_DNS_MODE_OFF;
-        } else if (checkedId == R.id.private_dns_mode_cloudflare) {
-            mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
         } else if (checkedId == R.id.private_dns_mode_opportunistic) {
             mMode = PRIVATE_DNS_MODE_OPPORTUNISTIC;
         } else if (checkedId == R.id.private_dns_mode_provider) {

--- a/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
+++ b/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
@@ -74,13 +74,11 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
 
     // Only used in Settings, update on additions to ConnectivitySettingsUtils
     private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
-    private static final int PRIVATE_DNS_MODE_ADGUARD = 5;
 
     static {
         PRIVATE_DNS_MAP = new HashMap<>();
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OFF, R.id.private_dns_mode_off);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLOUDFLARE, R.id.private_dns_mode_cloudflare);
-        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_ADGUARD, R.id.private_dns_mode_adguard);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OPPORTUNISTIC, R.id.private_dns_mode_opportunistic);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_PROVIDER_HOSTNAME, R.id.private_dns_mode_provider);
     }
@@ -155,12 +153,8 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
                     ConnectivitySettingsManager.getPrivateDnsHostname(context);
             final String cloudflareHostname =
                     context.getString(R.string.private_dns_hostname_cloudflare);
-            final String adguardHostname =
-                    context.getString(R.string.private_dns_hostname_adguard);
             if (privateDnsHostname.equals(cloudflareHostname)) {
                 mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
-            } else if (privateDnsHostname.equals(adguardHostname)) {
-                mMode = PRIVATE_DNS_MODE_ADGUARD;
             }
         }
 
@@ -178,9 +172,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
         final RadioButton cloudflareRadioButton =
                 view.findViewById(R.id.private_dns_mode_cloudflare);
         cloudflareRadioButton.setText(R.string.private_dns_mode_cloudflare);
-        final RadioButton adguardRadioButton =
-                view.findViewById(R.id.private_dns_mode_adguard);
-        adguardRadioButton.setText(R.string.private_dns_mode_adguard);
         final RadioButton opportunisticRadioButton =
                 view.findViewById(R.id.private_dns_mode_opportunistic);
         opportunisticRadioButton.setText(R.string.private_dns_mode_opportunistic);
@@ -216,11 +207,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
                         context.getString(R.string.private_dns_hostname_cloudflare);
                 ConnectivitySettingsManager.setPrivateDnsHostname(context, cloudflareHostname);
                 modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
-            } else if (mMode == PRIVATE_DNS_MODE_ADGUARD) {
-                final String adguardHostname =
-                        context.getString(R.string.private_dns_hostname_adguard);
-                ConnectivitySettingsManager.setPrivateDnsHostname(context, adguardHostname);
-                modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
             }
 
             FeatureFactory.getFactory(context).getMetricsFeatureProvider().action(context,
@@ -235,8 +221,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
             mMode = PRIVATE_DNS_MODE_OFF;
         } else if (checkedId == R.id.private_dns_mode_cloudflare) {
             mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
-        } else if (checkedId == R.id.private_dns_mode_adguard) {
-            mMode = PRIVATE_DNS_MODE_ADGUARD;
         } else if (checkedId == R.id.private_dns_mode_opportunistic) {
             mMode = PRIVATE_DNS_MODE_OPPORTUNISTIC;
         } else if (checkedId == R.id.private_dns_mode_provider) {

--- a/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
+++ b/src/com/android/settings/network/PrivateDnsModeDialogPreference.java
@@ -75,18 +75,12 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
     // Only used in Settings, update on additions to ConnectivitySettingsUtils
     private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
     private static final int PRIVATE_DNS_MODE_ADGUARD = 5;
-    private static final int PRIVATE_DNS_MODE_OPEN_DNS = 6;
-    private static final int PRIVATE_DNS_MODE_CLEANBROWSING = 7;
-    private static final int PRIVATE_DNS_MODE_QUAD9 = 8;
 
     static {
         PRIVATE_DNS_MAP = new HashMap<>();
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OFF, R.id.private_dns_mode_off);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLOUDFLARE, R.id.private_dns_mode_cloudflare);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_ADGUARD, R.id.private_dns_mode_adguard);
-        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OPEN_DNS, R.id.private_dns_mode_open_dns);
-        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_CLEANBROWSING, R.id.private_dns_mode_cleanbrowsing);
-        PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_QUAD9, R.id.private_dns_mode_quad9);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_OPPORTUNISTIC, R.id.private_dns_mode_opportunistic);
         PRIVATE_DNS_MAP.put(PRIVATE_DNS_MODE_PROVIDER_HOSTNAME, R.id.private_dns_mode_provider);
     }
@@ -163,22 +157,10 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
                     context.getString(R.string.private_dns_hostname_cloudflare);
             final String adguardHostname =
                     context.getString(R.string.private_dns_hostname_adguard);
-            final String opendnsHostname =
-                    context.getString(R.string.private_dns_hostname_open_dns);
-            final String cleanbrowsingHostname =
-                    context.getString(R.string.private_dns_hostname_cleanbrowsing);
-            final String quad9Hostname =
-                    context.getString(R.string.private_dns_hostname_quad9);
             if (privateDnsHostname.equals(cloudflareHostname)) {
                 mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
             } else if (privateDnsHostname.equals(adguardHostname)) {
                 mMode = PRIVATE_DNS_MODE_ADGUARD;
-            } else if (privateDnsHostname.equals(opendnsHostname)) {
-                mMode = PRIVATE_DNS_MODE_OPEN_DNS;
-            } else if (privateDnsHostname.equals(cleanbrowsingHostname)) {
-                mMode = PRIVATE_DNS_MODE_CLEANBROWSING;
-            } else if (privateDnsHostname.equals(quad9Hostname)) {
-                mMode = PRIVATE_DNS_MODE_QUAD9;
             }
         }
 
@@ -199,15 +181,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
         final RadioButton adguardRadioButton =
                 view.findViewById(R.id.private_dns_mode_adguard);
         adguardRadioButton.setText(R.string.private_dns_mode_adguard);
-        final RadioButton opendnsRadioButton =
-                view.findViewById(R.id.private_dns_mode_open_dns);
-        opendnsRadioButton.setText(R.string.private_dns_mode_open_dns);
-        final RadioButton cleanbrowsingRadioButton =
-                view.findViewById(R.id.private_dns_mode_cleanbrowsing);
-        cleanbrowsingRadioButton.setText(R.string.private_dns_mode_cleanbrowsing);
-        final RadioButton quad9RadioButton =
-                view.findViewById(R.id.private_dns_mode_quad9);
-        quad9RadioButton.setText(R.string.private_dns_mode_quad9);
         final RadioButton opportunisticRadioButton =
                 view.findViewById(R.id.private_dns_mode_opportunistic);
         opportunisticRadioButton.setText(R.string.private_dns_mode_opportunistic);
@@ -248,21 +221,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
                         context.getString(R.string.private_dns_hostname_adguard);
                 ConnectivitySettingsManager.setPrivateDnsHostname(context, adguardHostname);
                 modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
-            } else if (mMode == PRIVATE_DNS_MODE_OPEN_DNS) {
-                final String opendnsHostname =
-                        context.getString(R.string.private_dns_hostname_open_dns);
-                ConnectivitySettingsManager.setPrivateDnsHostname(context, opendnsHostname);
-                modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
-            } else if (mMode == PRIVATE_DNS_MODE_CLEANBROWSING) {
-                final String cleanbrowsingHostname =
-                        context.getString(R.string.private_dns_hostname_cleanbrowsing);
-                ConnectivitySettingsManager.setPrivateDnsHostname(context, cleanbrowsingHostname);
-                modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
-            } else if (mMode == PRIVATE_DNS_MODE_QUAD9) {
-                final String quad9Hostname =
-                        context.getString(R.string.private_dns_hostname_quad9);
-                ConnectivitySettingsManager.setPrivateDnsHostname(context, quad9Hostname);
-                modeToSet = PRIVATE_DNS_MODE_PROVIDER_HOSTNAME;
             }
 
             FeatureFactory.getFactory(context).getMetricsFeatureProvider().action(context,
@@ -279,12 +237,6 @@ public class PrivateDnsModeDialogPreference extends CustomDialogPreferenceCompat
             mMode = PRIVATE_DNS_MODE_CLOUDFLARE;
         } else if (checkedId == R.id.private_dns_mode_adguard) {
             mMode = PRIVATE_DNS_MODE_ADGUARD;
-        } else if (checkedId == R.id.private_dns_mode_open_dns) {
-            mMode = PRIVATE_DNS_MODE_OPEN_DNS;
-        } else if (checkedId == R.id.private_dns_mode_cleanbrowsing) {
-            mMode = PRIVATE_DNS_MODE_CLEANBROWSING;
-        } else if (checkedId == R.id.private_dns_mode_quad9) {
-            mMode = PRIVATE_DNS_MODE_QUAD9;
         } else if (checkedId == R.id.private_dns_mode_opportunistic) {
             mMode = PRIVATE_DNS_MODE_OPPORTUNISTIC;
         } else if (checkedId == R.id.private_dns_mode_provider) {

--- a/src/com/android/settings/network/PrivateDnsPreferenceController.java
+++ b/src/com/android/settings/network/PrivateDnsPreferenceController.java
@@ -65,6 +65,21 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
         Settings.Global.getUriFor(PRIVATE_DNS_SPECIFIER),
     };
 
+    // Must match ConnectivitySettingsUtils
+    private static final int PRIVATE_DNS_MODE_ADGUARD = 4;
+    private static final int PRIVATE_DNS_MODE_APPLIEDPRIVACY = 5;
+    private static final int PRIVATE_DNS_MODE_CLEANBROWSING = 6;
+    private static final int PRIVATE_DNS_MODE_CIRA = 7;
+    private static final int PRIVATE_DNS_MODE_CZNIC = 8;
+    private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 9;
+    private static final int PRIVATE_DNS_MODE_GOOGLE = 10;
+    private static final int PRIVATE_DNS_MODE_MULLVAD = 11;
+    private static final int PRIVATE_DNS_MODE_QUADNINE = 12;
+    private static final int PRIVATE_DNS_MODE_RESTENA = 13;
+    private static final int PRIVATE_DNS_MODE_SWITCH = 14;
+    private static final int PRIVATE_DNS_MODE_TWNIC = 15;
+    private static final int PRIVATE_DNS_MODE_UNCENSOREDDNS = 16;
+
     private final Handler mHandler;
     private final ContentObserver mSettingsObserver;
     private final ConnectivityManager mConnectivityManager;
@@ -129,6 +144,58 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
         switch (mode) {
             case PRIVATE_DNS_MODE_OFF:
                 return res.getString(R.string.private_dns_mode_off);
+            case PRIVATE_DNS_MODE_ADGUARD:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_adguard)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_APPLIEDPRIVACY:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_appliedprivacy)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_CIRA:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_cira)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_CLEANBROWSING:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_cleanbrowsing)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_CLOUDFLARE:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_cloudflare)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_CZNIC:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_cznic)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_GOOGLE:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_google)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_MULLVAD:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_mullvad)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_QUADNINE:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_quadnine)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_RESTENA:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_restena)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_SWITCH:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_switch)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_TWNIC:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_twnic)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
+            case PRIVATE_DNS_MODE_UNCENSOREDDNS:
+                return dnsesResolved
+                        ? res.getString(R.string.private_dns_mode_uncensoreddns)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
             case PRIVATE_DNS_MODE_OPPORTUNISTIC:
                 return dnsesResolved ? res.getString(R.string.private_dns_mode_on)
                         : res.getString(R.string.private_dns_mode_opportunistic);

--- a/src/com/android/settings/network/PrivateDnsPreferenceController.java
+++ b/src/com/android/settings/network/PrivateDnsPreferenceController.java
@@ -65,9 +65,6 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
         Settings.Global.getUriFor(PRIVATE_DNS_SPECIFIER),
     };
 
-    // Only used in Settings, update on additions to ConnectivitySettingsUtils
-    private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
-
     private final Handler mHandler;
     private final ContentObserver mSettingsObserver;
     private final ConnectivityManager mConnectivityManager;
@@ -132,22 +129,13 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
         switch (mode) {
             case PRIVATE_DNS_MODE_OFF:
                 return res.getString(R.string.private_dns_mode_off);
-            case PRIVATE_DNS_MODE_CLOUDFLARE:
             case PRIVATE_DNS_MODE_OPPORTUNISTIC:
                 return dnsesResolved ? res.getString(R.string.private_dns_mode_on)
                         : res.getString(R.string.private_dns_mode_opportunistic);
             case PRIVATE_DNS_MODE_PROVIDER_HOSTNAME:
-                if (!dnsesResolved) {
-                    return res.getString(R.string.private_dns_mode_provider_failure);
-                }
-                final String privateDnsHostname =
-                        ConnectivitySettingsManager.getPrivateDnsHostname(mContext);
-                final String cloudflareHostname =
-                        res.getString(R.string.private_dns_hostname_cloudflare);
-                if (privateDnsHostname.equals(cloudflareHostname)) {
-                    return res.getString(R.string.private_dns_mode_cloudflare);
-                }
-                return PrivateDnsModeDialogPreference.getHostnameFromSettings(cr);
+                return dnsesResolved
+                        ? PrivateDnsModeDialogPreference.getHostnameFromSettings(cr)
+                        : res.getString(R.string.private_dns_mode_provider_failure);
         }
         return "";
     }

--- a/src/com/android/settings/network/PrivateDnsPreferenceController.java
+++ b/src/com/android/settings/network/PrivateDnsPreferenceController.java
@@ -67,7 +67,6 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
 
     // Only used in Settings, update on additions to ConnectivitySettingsUtils
     private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
-    private static final int PRIVATE_DNS_MODE_ADGUARD = 5;
 
     private final Handler mHandler;
     private final ContentObserver mSettingsObserver;
@@ -134,7 +133,6 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
             case PRIVATE_DNS_MODE_OFF:
                 return res.getString(R.string.private_dns_mode_off);
             case PRIVATE_DNS_MODE_CLOUDFLARE:
-            case PRIVATE_DNS_MODE_ADGUARD:
             case PRIVATE_DNS_MODE_OPPORTUNISTIC:
                 return dnsesResolved ? res.getString(R.string.private_dns_mode_on)
                         : res.getString(R.string.private_dns_mode_opportunistic);
@@ -146,12 +144,8 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
                         ConnectivitySettingsManager.getPrivateDnsHostname(mContext);
                 final String cloudflareHostname =
                         res.getString(R.string.private_dns_hostname_cloudflare);
-                final String adguardHostname =
-                        res.getString(R.string.private_dns_hostname_adguard);
                 if (privateDnsHostname.equals(cloudflareHostname)) {
                     return res.getString(R.string.private_dns_mode_cloudflare);
-                } else if (privateDnsHostname.equals(adguardHostname)) {
-                    return res.getString(R.string.private_dns_mode_adguard);
                 }
                 return PrivateDnsModeDialogPreference.getHostnameFromSettings(cr);
         }

--- a/src/com/android/settings/network/PrivateDnsPreferenceController.java
+++ b/src/com/android/settings/network/PrivateDnsPreferenceController.java
@@ -68,9 +68,6 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
     // Only used in Settings, update on additions to ConnectivitySettingsUtils
     private static final int PRIVATE_DNS_MODE_CLOUDFLARE = 4;
     private static final int PRIVATE_DNS_MODE_ADGUARD = 5;
-    private static final int PRIVATE_DNS_MODE_OPEN_DNS = 6;
-    private static final int PRIVATE_DNS_MODE_CLEANBROWSING = 7;
-    private static final int PRIVATE_DNS_MODE_QUAD9 = 8;
 
     private final Handler mHandler;
     private final ContentObserver mSettingsObserver;
@@ -138,9 +135,6 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
                 return res.getString(R.string.private_dns_mode_off);
             case PRIVATE_DNS_MODE_CLOUDFLARE:
             case PRIVATE_DNS_MODE_ADGUARD:
-            case PRIVATE_DNS_MODE_OPEN_DNS:
-            case PRIVATE_DNS_MODE_CLEANBROWSING:
-            case PRIVATE_DNS_MODE_QUAD9:
             case PRIVATE_DNS_MODE_OPPORTUNISTIC:
                 return dnsesResolved ? res.getString(R.string.private_dns_mode_on)
                         : res.getString(R.string.private_dns_mode_opportunistic);
@@ -154,22 +148,10 @@ public class PrivateDnsPreferenceController extends BasePreferenceController
                         res.getString(R.string.private_dns_hostname_cloudflare);
                 final String adguardHostname =
                         res.getString(R.string.private_dns_hostname_adguard);
-                final String opendnsHostname =
-                        res.getString(R.string.private_dns_hostname_open_dns);
-                final String cleanbrowsingHostname =
-                        res.getString(R.string.private_dns_hostname_cleanbrowsing);
-                final String quad9Hostname =
-                        res.getString(R.string.private_dns_hostname_quad9);
                 if (privateDnsHostname.equals(cloudflareHostname)) {
                     return res.getString(R.string.private_dns_mode_cloudflare);
                 } else if (privateDnsHostname.equals(adguardHostname)) {
                     return res.getString(R.string.private_dns_mode_adguard);
-                } else if (privateDnsHostname.equals(opendnsHostname)) {
-                    return res.getString(R.string.private_dns_mode_open_dns);
-                } else if (privateDnsHostname.equals(cleanbrowsingHostname)) {
-                    return res.getString(R.string.private_dns_mode_cleanbrowsing);
-                } else if (privateDnsHostname.equals(quad9Hostname)) {
-                    return res.getString(R.string.private_dns_mode_quad9);
                 }
                 return PrivateDnsModeDialogPreference.getHostnameFromSettings(cr);
         }


### PR DESCRIPTION
On devices that have more than one high refresh rate (eg. 90/120/144 Hz) allow choosing any of those as the peak refresh rate rather than offering only the maximum as a toggle. Use a radio picker preference, similar to screen timeout and display resolution settings. Also add a toggle for VRR that sets the minimum refresh rate.