### PR TITLE
Add string resource for device name title

### DIFF
--- a/res/values/strings.xml
+++ b/res/values/strings.xml
@@ -348,6 +348,8 @@
     <string name="previous_connected_see_all">See all</string>
     <!-- Title to see all fast pair devices [CHAR LIMIT=none]-->
     <string name="connected_device_fast_pair_device_see_all">See all</string>
+     <!-- Title for device name -->
+     <string name="about_device_name_title">Device name</string>
 
     <!-- Title for stylus device details page [CHAR LIMIT=50] -->
     <string name="stylus_device_details_title">Stylus</string>


### PR DESCRIPTION
Title:

Fix missing "about_device_name_title" string in Settings (A16)

Description:

During A16 builds, the Settings app fails to compile due to an unresolved reference in DeviceCardView.kt:

R.string.about_device_name_title


This string is referenced here:

packages/apps/Settings/src/com/android/settings/deviceinfo/aboutphone/DeviceCardView.kt


But the corresponding resource is missing from:

packages/apps/Settings/res/values/strings.xml


This causes the build to fail with:

error: unresolved reference 'about_device_name_title'


Adding the missing resource resolves the issue across all devices, not only fogos (Moto G34 5G).

Fix:
<string name="about_device_name_title">Device name</string>

Explanation:

This string exists in upstream AOSP/LineageOS but was not included during AlphaDroid A16 rebasing. Adding it aligns Settings with upstream and restores successful compilation.